### PR TITLE
Make tasty-rerun compatible to GHC 8.0, release as 1.1.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 1.1.6
+
+* Allow base 4.9 for building with GHC 8.0
+
 # 1.1.5
 
 * Supports tasty < 0.12.

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "tasty-rerun";
-  version = "1.1.4";
+  version = "1.1.6";
   src = ./.;
   buildDepends = [
     base containers mtl optparse-applicative reducers split stm tagged

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let pkg = haskellngPackages.callPackage
              }:
              mkDerivation {
                pname = "tasty-rerun";
-               version = "1.1.4";
+               version = "1.1.6";
                src = ./.;
                buildDepends = [
                  base containers mtl optparse-applicative reducers split stm tagged

--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -72,7 +72,7 @@ description:
 library
   exposed-modules:     Test.Tasty.Ingredients.Rerun
   build-depends:
-    base >=4.6 && <4.9,
+    base >=4.6 && <4.10,
     containers >= 0.5.0.0,
     mtl >= 2.1.2,
     optparse-applicative >= 0.6,

--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -1,5 +1,5 @@
 name:                tasty-rerun
-version:             1.1.5
+version:             1.1.6
 homepage:            http://github.com/ocharles/tasty-rerun
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
Allow base-4.9 to make tasty-rerun compatible with GHC 8.0 and release this as version 1.1.6.