### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -72,7 +72,7 @@ description:
 library
   exposed-modules:     Test.Tasty.Ingredients.Rerun
   build-depends:
-    base >=4.6 && <4.10,
+    base >=4.6 && <4.11,
     containers >= 0.5.0.0,
     mtl >= 2.1.2,
     optparse-applicative >= 0.6,


### PR DESCRIPTION
GHC 8.2 ships with base-4.10.
The package still builds after the bump.