### PR TITLE
Use `System.IO.readFile'` to read the state file

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -48,9 +48,9 @@ jobs:
             compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -63,42 +63,12 @@ jobs:
             compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.8.4
-            compilerKind: ghc
-            compilerVersion: 8.8.4
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.6.5
-            compilerKind: ghc
-            compilerVersion: 8.6.5
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
@@ -234,8 +204,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_tasty_rerun}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package tasty-rerun" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package tasty-rerun" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           if $HEADHACKAGE; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
+dist-newstyle/
 *~

--- a/src/Test/Tasty/Ingredients/Rerun.hs
+++ b/src/Test/Tasty/Ingredients/Rerun.hs
@@ -75,7 +75,7 @@ import Data.Monoid (Any(..), Monoid(..))
 import Data.Ord (Ord)
 import Data.Proxy (Proxy(..))
 import Data.String (String)
-import System.IO (FilePath, IO, readFile, writeFile)
+import System.IO (FilePath, IO, readFile', writeFile)
 import System.IO.Error (catchIOError, isDoesNotExistError, ioError)
 import Text.Read (Read, read)
 import Text.Show (Show, show)
@@ -282,7 +282,7 @@ rerunningTests ingredients =
 
   tryLoadStateFrom :: FilePath -> IO (Maybe (Map.Map [String] TestResult))
   tryLoadStateFrom filePath = do
-    fileContents <- (Just <$> readFile filePath)
+    fileContents <- (Just <$> readFile' filePath)
                       `catchIOError` (\e -> if isDoesNotExistError e
                                               then return Nothing
                                               else ioError e)

--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -27,8 +27,7 @@ description:
 
 tested-with:
   GHC==9.12.1, GHC==9.10.1, GHC==9.8.4,
-  GHC==9.6.6, GHC==9.4.5, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7,
-  GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
+  GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2
 
 source-repository head
   type: git
@@ -37,7 +36,7 @@ source-repository head
 library
   exposed-modules:     Test.Tasty.Ingredients.Rerun
   build-depends:
-    base >=4.9 && <4.22,
+    base >=4.15 && <4.22,
     containers >= 0.5.0.0 && < 0.8,
     mtl >= 2.1.2 && < 2.4,
     optparse-applicative >= 0.6 && < 0.19,


### PR DESCRIPTION
I also considered using `System.IO.readFile'`, but that function is only available since `base-4.15.0.0` (i.e. GHC 9.0 if I am not mistaken), which would IMHO restrict our GHC compatibiliy too much.
So I decided to go with `Data.Text.IO.readFile` here instead: The `text` package is pulled in as a dependency by `optparse-applicative` anyway, so the overall dependency footprint did not grow.

Fixes #23 