### PR TITLE
Per executable test log file

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241202
+# version: 0.19.20250115
 #
-# REGENDATA ("0.19.20241202",["github","tasty-rerun.cabal"])
+# REGENDATA ("0.19.20250115",["github","tasty-rerun.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.0.20241128
+          - compiler: ghc-9.12.1
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241128
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.12.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
@@ -51,16 +51,6 @@ jobs:
           - compiler: ghc-9.4.8
             compilerKind: ghc
             compilerVersion: 9.4.8
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.2.8
-            compilerKind: ghc
-            compilerVersion: 9.2.8
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.0.2
-            compilerKind: ghc
-            compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
       fail-fast: false
@@ -92,21 +82,6 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -117,7 +92,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -145,18 +120,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -208,9 +171,6 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(tasty-rerun)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/src/Test/Tasty/Ingredients/Rerun.hs
+++ b/src/Test/Tasty/Ingredients/Rerun.hs
@@ -75,7 +75,6 @@ import Data.Monoid (Any(..), Monoid(..))
 import Data.Ord (Ord)
 import Data.Proxy (Proxy(..))
 import Data.String (String)
-import System.Environment (getExecutablePath)
 import System.FilePath ((<.>), takeBaseName)
 import System.IO (FilePath, IO, readFile', writeFile)
 import System.IO.Error (catchIOError, isDoesNotExistError, ioError)
@@ -89,6 +88,7 @@ import qualified Data.IntMap as IntMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Options.Applicative as OptParse
+import qualified System.Environment
 import qualified Test.Tasty.Options as Tasty
 import qualified Test.Tasty.Runners as Tasty
 
@@ -206,8 +206,12 @@ rerunningTests ingredients =
     \options testTree -> Just $ do
       stateFile <- case Tasty.lookupOption options of
         DefaultRerunLogFile -> do
-            executableName <- takeBaseName <$> getExecutablePath
-            return (".tasty-rerun-log" <.> executableName)
+            maybeExecutablePath <-
+                fromMaybe (return Nothing) System.Environment.executablePath
+            case maybeExecutablePath of
+                Nothing -> return ".tasty-rerun-log"
+                Just executablePath ->
+                    return (".tasty-rerun-log" <.> takeBaseName executablePath)
         CustomRerunLogFile stateFile -> return stateFile
 
       let (UpdateLog updateLog, AllOnSuccess allOnSuccess, FilterOption filter)

--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -27,7 +27,7 @@ description:
 
 tested-with:
   GHC==9.12.1, GHC==9.10.1, GHC==9.8.4,
-  GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2
+  GHC==9.6.6, GHC==9.4.8
 
 source-repository head
   type: git
@@ -36,7 +36,7 @@ source-repository head
 library
   exposed-modules:     Test.Tasty.Ingredients.Rerun
   build-depends:
-    base >=4.15 && <4.22,
+    base >=4.17 && <4.22,
     containers >= 0.5.0.0 && < 0.9,
     filepath < 1.6,
     mtl >= 2.1.2 && < 2.4,

--- a/tasty-rerun.cabal
+++ b/tasty-rerun.cabal
@@ -38,6 +38,7 @@ library
   build-depends:
     base >=4.15 && <4.22,
     containers >= 0.5.0.0 && < 0.9,
+    filepath < 1.6,
     mtl >= 2.1.2 && < 2.4,
     optparse-applicative >= 0.6 && < 0.19,
     split >= 0.1 && < 0.3,


### PR DESCRIPTION
With this PR the base name of the calling executable is appended to the name of the log file (as suggested in https://github.com/ocharles/tasty-rerun/issues/22#issuecomment-2543396610).
Only the _default_ log file name is adjusted, custom log file locations specified using `--rerun-log-file` are used as is.